### PR TITLE
feat: ci simple run python

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,9 +46,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version:
-          ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy2.7', 'pypy3.8']
+          # ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy2.7', 'pypy3.8']
+          ['3.10']
         exclude:
           - os: macos-latest
             python-version: '3.8'


### PR DESCRIPTION
ciで `for-python`がmulti-runになっていた部分をやめた（githubへの負荷を上げる必要がないため）