### PR TITLE
fix: APIリクエストとエラーログの最適化

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import './App.scss';
 import LoadingSpinner from './components/atoms/LoadingSpinner';
 import { GitHubProvider } from './contexts/GitHubContext';
 import { SlackProvider } from './contexts/SlackContext';
+import { ToastProvider } from './contexts/ToastContext';
 import HomePage from './pages/HomePage';
 import TokenCheck from './pages/TokenCheck';
 
@@ -58,22 +59,24 @@ const App: React.FC = () => {
   return (
     <Router>
       <div className="app">
-        <GitHubProvider>
-          <SlackProvider>
-            <NavBar />
+        <ToastProvider>
+          <GitHubProvider>
+            <SlackProvider>
+              <NavBar />
 
-            <main className="app-content">
-              <Suspense fallback={<LoadingSpinner />}>
-                <Routes>
-                  <Route path="/" element={<HomePage />} />
-                  <Route path="/token-check" element={<TokenCheck />} />
-                  <Route path="/slack" element={<SlackPage />} />
-                  <Route path="*" element={<Navigate to="/" replace />} />
-                </Routes>
-              </Suspense>
-            </main>
-          </SlackProvider>
-        </GitHubProvider>
+              <main className="app-content">
+                <Suspense fallback={<LoadingSpinner />}>
+                  <Routes>
+                    <Route path="/" element={<HomePage />} />
+                    <Route path="/token-check" element={<TokenCheck />} />
+                    <Route path="/slack" element={<SlackPage />} />
+                    <Route path="*" element={<Navigate to="/" replace />} />
+                  </Routes>
+                </Suspense>
+              </main>
+            </SlackProvider>
+          </GitHubProvider>
+        </ToastProvider>
       </div>
     </Router>
   );

--- a/src/components/atoms/Toast.scss
+++ b/src/components/atoms/Toast.scss
@@ -1,0 +1,71 @@
+@use '@/styles/index.scss' as *;
+
+.toast {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  padding: 12px 16px;
+  border-radius: 4px;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 300px;
+  max-width: 450px;
+  z-index: 1000;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: all 0.3s ease;
+  pointer-events: none;
+
+  &.visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: all;
+  }
+
+  .toast-content {
+    display: flex;
+    align-items: center;
+    flex: 1;
+  }
+
+  .toast-message {
+    font-size: 14px;
+    margin-left: 8px;
+  }
+
+  .toast-close {
+    background: none;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+    color: inherit;
+    opacity: 0.7;
+    padding: 0 0 0 10px;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  &.toast-success {
+    background-color: #4caf50;
+    color: white;
+  }
+
+  &.toast-error {
+    background-color: #f44336;
+    color: white;
+  }
+
+  &.toast-warning {
+    background-color: #ff9800;
+    color: white;
+  }
+
+  &.toast-info {
+    background-color: #2196f3;
+    color: white;
+  }
+}

--- a/src/components/atoms/Toast.tsx
+++ b/src/components/atoms/Toast.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect } from 'react';
+import './Toast.scss';
+
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+interface ToastProps {
+  message: string;
+  type: ToastType;
+  duration?: number;
+  onClose: () => void;
+  isVisible: boolean;
+}
+
+const Toast: React.FC<ToastProps> = ({
+  message,
+  type,
+  duration = 3000,
+  onClose,
+  isVisible,
+}) => {
+  useEffect(() => {
+    let timer: NodeJS.Timeout | undefined;
+
+    if (isVisible) {
+      timer = setTimeout(() => {
+        onClose();
+      }, duration);
+    }
+
+    return () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+  }, [duration, isVisible, onClose]);
+
+  if (!isVisible) return null;
+
+  return (
+    <div className={`toast toast-${type} ${isVisible ? 'visible' : ''}`}>
+      <div className="toast-content">
+        <span className="toast-message">{message}</span>
+      </div>
+      <button className="toast-close" onClick={onClose}>
+        ×
+      </button>
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/components/molecules/slack/CreateChannelForm.scss
+++ b/src/components/molecules/slack/CreateChannelForm.scss
@@ -1,61 +1,55 @@
+@use '@/styles/index.scss' as *;
 @use '../../../styles/variables/typography' as *;
 @use '../../../styles/variables/colors' as *;
 @use '../../../styles/variables/spacing' as *;
 @use '../../../styles/variables/borders' as *;
 
 .create-channel-form {
-  border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-md);
-  padding: var(--spacing-md);
-  margin-bottom: var(--spacing-md);
-  background-color: white;
+  background-color: #fff;
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 30px;
 
   h3 {
     margin-top: 0;
-    margin-bottom: var(--spacing-md);
-    color: var(--text-color);
+    margin-bottom: 16px;
+    color: #2c3e50;
   }
 
   .form-description {
-    background-color: var(--background-color);
-    padding: var(--spacing-sm);
-    border-radius: var(--border-radius-sm);
-    margin-bottom: var(--spacing-md);
-
-    p {
-      margin: 0;
-      color: var(--secondary-text-color);
-      font-size: var(--font-size-sm);
-    }
+    margin-bottom: 20px;
+    color: #666;
+    font-size: 14px;
+    line-height: 1.5;
   }
 
   .form-group {
-    margin-bottom: var(--spacing-md);
+    margin-bottom: 20px;
 
     label {
       display: block;
-      margin-bottom: var(--spacing-sm);
-      font-weight: bold;
-      color: var(--text-color);
+      margin-bottom: 8px;
+      font-weight: 500;
+      color: #333;
     }
 
     select,
     textarea {
       width: 100%;
-      padding: var(--spacing-sm);
-      border: 1px solid var(--border-color);
-      border-radius: var(--border-radius-sm);
-      background-color: white;
-      font-size: var(--font-size-base);
+      padding: 10px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      font-size: 14px;
 
       &:focus {
         outline: none;
-        border-color: var(--primary-color);
-        box-shadow: 0 0 0 2px rgba(var(--primary-color-rgb), 0.1);
+        border-color: #3498db;
+        box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
       }
 
       &:disabled {
-        background-color: var(--background-color);
+        background-color: #f5f5f5;
         cursor: not-allowed;
       }
     }
@@ -64,24 +58,45 @@
       min-height: 100px;
       resize: vertical;
     }
+
+    .members-select {
+      min-height: 150px;
+
+      option {
+        padding: 8px;
+
+        &:checked {
+          background-color: #3498db;
+          color: white;
+        }
+      }
+    }
+
+    .help-text {
+      display: block;
+      margin-top: 6px;
+      font-size: 12px;
+      color: #777;
+    }
   }
 
   button {
-    background-color: var(--primary-color);
+    background-color: #3498db;
     color: white;
     border: none;
-    padding: var(--spacing-sm) var(--spacing-md);
-    border-radius: var(--border-radius-sm);
-    font-weight: bold;
+    padding: 12px 20px;
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: 500;
     cursor: pointer;
-    transition: background-color 0.2s ease;
+    transition: background-color 0.2s;
 
     &:hover:not(:disabled) {
-      filter: brightness(0.9);
+      background-color: #2980b9;
     }
 
     &:disabled {
-      background-color: var(--border-color);
+      background-color: #95a5a6;
       cursor: not-allowed;
     }
   }

--- a/src/components/molecules/slack/CreateChannelForm.tsx
+++ b/src/components/molecules/slack/CreateChannelForm.tsx
@@ -1,6 +1,11 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useToast } from '../../../contexts/ToastContext';
 import { Repository } from '../../../services/github/repositoryService';
-import { CreateChannelParams } from '../../../services/slack/channelService';
+import {
+  CreateChannelParams,
+  SlackUser,
+  getSlackUsers,
+} from '../../../services/slack/channelService';
 import './CreateChannelForm.scss';
 
 interface CreateChannelFormProps {
@@ -16,18 +21,78 @@ const CreateChannelForm: React.FC<CreateChannelFormProps> = ({
 }) => {
   const [selectedRepo, setSelectedRepo] = useState<string>('');
   const [description, setDescription] = useState<string>('');
+  const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
+  const [users, setUsers] = useState<SlackUser[]>([]);
+  const [loadingUsers, setLoadingUsers] = useState<boolean>(false);
+  const { showToast } = useToast();
+
+  // コンポーネントマウント時にSlackユーザーリストを取得
+  useEffect(() => {
+    let isMounted = true;
+    const fetchUsers = async () => {
+      try {
+        setLoadingUsers(true);
+        const slackUsers = await getSlackUsers();
+        if (isMounted) {
+          setUsers(slackUsers);
+        }
+      } catch (error: any) {
+        // 429エラー（Too Many Requests）の場合は、エラーログを出力しない
+        if (!(error.response && error.response.status === 429)) {
+          console.error('Failed to fetch Slack users:', error);
+        }
+        if (isMounted) {
+          // 429エラーの場合は特定のエラーメッセージを表示しない
+          if (!(error.response && error.response.status === 429)) {
+            showToast('Slackユーザーの取得に失敗しました', 'error');
+          }
+        }
+      } finally {
+        if (isMounted) {
+          setLoadingUsers(false);
+        }
+      }
+    };
+
+    fetchUsers();
+
+    // クリーンアップ関数
+    return () => {
+      isMounted = false;
+    };
+  }, []); // 空の依存配列で初回のみ実行
+
+  const handleMemberChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const options = Array.from(e.target.selectedOptions);
+    const selectedValues = options.map(option => option.value);
+    setSelectedMembers(selectedValues);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!selectedRepo) return;
 
-    await onSubmit({
-      repositoryName: selectedRepo,
-      description: description || undefined,
-    });
-    // フォームをリセット
-    setSelectedRepo('');
-    setDescription('');
+    try {
+      await onSubmit({
+        repositoryName: selectedRepo,
+        description: description || undefined,
+        members: selectedMembers.length > 0 ? selectedMembers : undefined,
+      });
+
+      // 成功メッセージをトースト通知で表示
+      showToast(`チャンネルが正常に作成されました`, 'success');
+
+      // フォームをリセット
+      setSelectedRepo('');
+      setDescription('');
+      setSelectedMembers([]);
+    } catch (error) {
+      // エラーメッセージをトースト通知で表示
+      showToast(
+        `チャンネル作成に失敗しました: ${error instanceof Error ? error.message : 'エラーが発生しました'}`,
+        'error',
+      );
+    }
   };
 
   return (
@@ -67,6 +132,31 @@ const CreateChannelForm: React.FC<CreateChannelFormProps> = ({
           placeholder="チャンネルの目的や用途を入力してください"
           disabled={isLoading}
         />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="members">チャンネルメンバー（オプション）:</label>
+        <select
+          id="members"
+          multiple
+          value={selectedMembers}
+          onChange={handleMemberChange}
+          disabled={isLoading || loadingUsers}
+          className="members-select"
+        >
+          {loadingUsers ? (
+            <option disabled>ユーザーを読み込み中...</option>
+          ) : (
+            users.map(user => (
+              <option key={user.id} value={user.id}>
+                {user.profile.display_name || user.real_name || user.name}
+              </option>
+            ))
+          )}
+        </select>
+        <small className="help-text">
+          Ctrlキー（Macの場合はCommandキー）を押しながらクリックして複数選択できます
+        </small>
       </div>
 
       <button type="submit" disabled={isLoading || !selectedRepo}>

--- a/src/components/molecules/slack/NotificationSettingForm.tsx
+++ b/src/components/molecules/slack/NotificationSettingForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useToast } from '../../../contexts/ToastContext';
 import { SlackChannel } from '../../../services/slack/channelService';
 import { NotificationSetting } from '../../../services/slack/notificationService';
 import './NotificationSettingForm.scss';
@@ -16,8 +17,10 @@ const NotificationSettingForm: React.FC<NotificationSettingFormProps> = ({
   const [events, setEvents] = useState<string[]>([]);
   const [owner, setOwner] = useState<string>('');
   const [repo, setRepo] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const { showToast } = useToast();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!channelId || events.length === 0 || !owner || !repo) return;
 
@@ -27,13 +30,30 @@ const NotificationSettingForm: React.FC<NotificationSettingFormProps> = ({
       repositories: [{ owner, repo }],
     };
 
-    onSave(setting);
+    // 送信中状態にする
+    setIsSubmitting(true);
 
-    // フォームをリセット
-    setChannelId('');
-    setEvents([]);
-    setOwner('');
-    setRepo('');
+    try {
+      await onSave(setting);
+
+      // 成功メッセージをトースト通知で表示
+      showToast('通知設定が正常に保存されました', 'success');
+
+      // フォームをリセット
+      setChannelId('');
+      setEvents([]);
+      setOwner('');
+      setRepo('');
+    } catch (error) {
+      // エラーメッセージをトースト通知で表示
+      showToast(
+        `通知設定の保存に失敗しました: ${error instanceof Error ? error.message : 'エラーが発生しました'}`,
+        'error',
+      );
+    } finally {
+      // 送信中状態を解除
+      setIsSubmitting(false);
+    }
   };
 
   const handleEventChange = (event: string) => {
@@ -183,9 +203,11 @@ const NotificationSettingForm: React.FC<NotificationSettingFormProps> = ({
 
         <button
           type="submit"
-          disabled={!channelId || events.length === 0 || !owner || !repo}
+          disabled={
+            isSubmitting || !channelId || events.length === 0 || !owner || !repo
+          }
         >
-          保存
+          {isSubmitting ? '保存中...' : '保存'}
         </button>
       </form>
     </div>

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,0 +1,59 @@
+import React, { ReactNode, createContext, useContext, useState } from 'react';
+import Toast, { ToastType } from '../components/atoms/Toast';
+
+interface ToastContextType {
+  showToast: (message: string, type: ToastType) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+interface ToastProviderProps {
+  children: ReactNode;
+}
+
+export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
+  const [toast, setToast] = useState<{
+    message: string;
+    type: ToastType;
+    isVisible: boolean;
+  }>({
+    message: '',
+    type: 'info',
+    isVisible: false,
+  });
+
+  const showToast = (message: string, type: ToastType) => {
+    setToast({
+      message,
+      type,
+      isVisible: true,
+    });
+  };
+
+  const hideToast = () => {
+    setToast(prev => ({
+      ...prev,
+      isVisible: false,
+    }));
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <Toast
+        message={toast.message}
+        type={toast.type}
+        isVisible={toast.isVisible}
+        onClose={hideToast}
+      />
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = (): ToastContextType => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+};

--- a/src/services/slack/channelService.ts
+++ b/src/services/slack/channelService.ts
@@ -23,10 +23,34 @@ export interface SlackMessage {
   type: string;
 }
 
+export interface SlackUser {
+  id: string;
+  name: string;
+  real_name: string;
+  profile: {
+    display_name: string;
+    email?: string;
+    image_24?: string;
+  };
+}
+
 export interface CreateChannelParams {
   repositoryName: string;
   description?: string | undefined;
+  members?: string[] | undefined; // メンバーのIDリスト
 }
+
+// ユーザーリストのキャッシュデータ
+interface UserCache {
+  users: SlackUser[];
+  timestamp: number;
+}
+
+// キャッシュの有効期間（10分 = 600,000ミリ秒）
+const CACHE_DURATION = 600000;
+
+// ユーザーリストのキャッシュ
+let userCache: UserCache | null = null;
 
 export const getChannels = async (): Promise<SlackChannel[]> => {
   try {
@@ -103,20 +127,70 @@ export const getGithubAppPermissions = async (
   ];
 };
 
+export const getSlackUsers = async (): Promise<SlackUser[]> => {
+  // キャッシュがあり、まだ有効期間内であれば、キャッシュを返す
+  const now = Date.now();
+  if (userCache && now - userCache.timestamp < CACHE_DURATION) {
+    return userCache.users;
+  }
+
+  try {
+    const response = await slackApiClient.get('/users.list');
+    const users = response.data.members.filter(
+      (member: any) => !member.is_bot && !member.deleted,
+    );
+
+    // 結果をキャッシュに保存
+    userCache = {
+      users,
+      timestamp: now,
+    };
+
+    return users;
+  } catch (error: any) {
+    // キャッシュが存在する場合は常にキャッシュのデータを返す
+    if (userCache) {
+      // 429エラー（Too Many Requests）の場合は、エラーログを出力しない
+      if (!(error.response && error.response.status === 429)) {
+        console.error('Failed to fetch Slack users:', error);
+      }
+      return userCache.users;
+    }
+
+    // キャッシュがない場合、429エラー以外は通常通りログを出力
+    if (!(error.response && error.response.status === 429)) {
+      console.error('Failed to fetch Slack users:', error);
+    }
+    throw error;
+  }
+};
+
 export const createLogChannel = async (
   params: CreateChannelParams,
 ): Promise<SlackChannel> => {
   const channelName = `log_gh_${params.repositoryName.toLowerCase()}`;
   try {
+    // チャンネルを作成
     const response = await slackApiClient.post('/conversations.create', {
       name: channelName,
       is_private: false,
     });
 
+    const channelId = response.data.channel.id;
+
+    // 説明を設定（オプション）
     if (params.description) {
       await slackApiClient.post('/conversations.setPurpose', {
-        channel: response.data.channel.id,
+        channel: channelId,
         purpose: params.description,
+      });
+    }
+
+    // メンバーを招待（オプション）
+    if (params.members && params.members.length > 0) {
+      await slackApiClient.post('/conversations.invite', {
+        channel: channelId,
+        users: params.members.join(','),
       });
     }
 

--- a/src/services/slack/notificationService.ts
+++ b/src/services/slack/notificationService.ts
@@ -54,7 +54,6 @@ export const markAsRead = async (notificationId: string): Promise<void> => {
   try {
     // 実際のAPIがない場合は成功を返す
     console.log(`Marking notification ${notificationId} as read`);
-    return;
   } catch (error) {
     console.error('Failed to mark notification as read:', error);
     throw error;


### PR DESCRIPTION
- Slackユーザーリスト取得にキャッシュ機能を追加(10分間有効)
- 429エラー(Too Many Requests)発生時の不要なログ出力を抑制
- useEffectでのAPIリクエスト呼び出しを最適化
- APIエラー時のエラーハンドリングを改善

Issue #1498

## Issue

close #1498

### 作成内容

- [Issue](https://github.com/KonishiKenji/test-various-tools/issues/{IssueNumber})

## 確認事項

〜特になければ項目自体削除

## 備考
